### PR TITLE
store cypress artifacts in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,4 +4,9 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run
+      - cypress/run:
+          post-steps:
+            - store_artifacts:
+                path: cypress/videos
+            - store_artiacts:
+                path: cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,5 @@ workflows:
           post-steps:
             - store_artifacts:
                 path: cypress/videos
-            - store_artiacts:
+            - store_artifacts:
                 path: cypress/screenshots


### PR DESCRIPTION
Proof this change will work: https://app.circleci.com/pipelines/github/joinpursuit/Module-Two-Midmodule-Assessment/16/workflows/0ad7775b-2e0b-4089-80f9-9cdfd44079c3/jobs/16/artifacts

This will store the cypress artifacts (screenshots and test run videos) in the `Artifacts` tab in Circle CI after the test runs. The assessment is in progress now and I don't want people to start seeing merge conflict notices on their PRs, but I propose we merge this after the 7.1 assessments are in. Then during grading time we can rerun PRs that aren't ✅   and view the artifacts.